### PR TITLE
Return proper exit code when runc exits with an error

### DIFF
--- a/main.go
+++ b/main.go
@@ -99,13 +99,18 @@ func launchRunc(runcPath string, runcArgs []string) int {
 	}()
 
 	err = cmd.Wait()
+
+	return processRuncError(err)
+}
+
+func processRuncError(err error) int {
 	if err != nil {
 		if exit, ok := err.(*exec.ExitError); ok {
 			// We had a nonzero exitCode
 			if code, ok := exit.Sys().(syscall.WaitStatus); ok {
 				// and the code is retrievable
 				// so we exit with the same code
-				return int(code)
+				return code.ExitStatus()
 			}
 		}
 		// If we can't get the error code, still exit with error

--- a/main_test.go
+++ b/main_test.go
@@ -1,10 +1,42 @@
 package main
 
 import (
+	"errors"
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"syscall"
 	"testing"
 )
+
+func TestRuncError(t *testing.T) {
+	exitCmd := exec.Command("/bin/sh", "-c 'exit 2'")
+	exitErr := exitCmd.Run()
+	cases := []struct {
+		err      error
+		expected int
+	}{
+		{
+			err:      nil,
+			expected: 0,
+		},
+		{
+			err:      errors.New("simple error"),
+			expected: 1,
+		},
+		{
+			err:      exitErr,
+			expected: 2,
+		},
+	}
+	for _, c := range cases {
+		val := processRuncError(c.err)
+		if val != c.expected {
+			t.Errorf("Expected %d but got %d", c.expected, val)
+		}
+	}
+}
 
 func TestVerifyRuntimePath(t *testing.T) {
 	upDir := filepath.Join(os.TempDir(), "made-up-dir-42")


### PR DESCRIPTION
*Description of changes:*

Properly grab the exit code of runc if it exits in error.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
