### PR TITLE
support new oci hooks

### DIFF
--- a/hook.go
+++ b/hook.go
@@ -25,9 +25,12 @@ func (c *config) MarshalJSON() ([]byte, error) {
 type hooks struct {
 	lossless.JSON `json:"-"`
 
-	Prestart  []json.RawMessage `json:"prestart"`
-	Poststart []json.RawMessage `json:poststart"`
-	Poststop  []json.RawMessage `json:poststop"`
+	Prestart        []json.RawMessage `json:"prestart"`
+	CreateRuntime   []json.RawMessage `json:"createRuntime"`
+	CreateContainer []json.RawMessage `json:"createContainer"`
+	StartContainer  []json.RawMessage `json:"startContainer"`
+	Poststart       []json.RawMessage `json:poststart"`
+	Poststop        []json.RawMessage `json:poststop"`
 }
 
 func (h *hooks) UnmarshalJSON(data []byte) error {
@@ -62,6 +65,9 @@ func (c *config) merge(in *config) {
 		return
 	}
 	c.Hooks.Prestart = mergeHook(c.Hooks.Prestart, in.Hooks.Prestart)
+	c.Hooks.CreateRuntime = mergeHook(c.Hooks.CreateRuntime, in.Hooks.CreateRuntime)
+	c.Hooks.CreateContainer = mergeHook(c.Hooks.CreateContainer, in.Hooks.CreateContainer)
+	c.Hooks.StartContainer = mergeHook(c.Hooks.StartContainer, in.Hooks.StartContainer)
 	c.Hooks.Poststart = mergeHook(c.Hooks.Poststart, in.Hooks.Poststart)
 	c.Hooks.Poststop = mergeHook(c.Hooks.Poststop, in.Hooks.Poststop)
 }

--- a/hook_test.go
+++ b/hook_test.go
@@ -97,9 +97,12 @@ func TestReadHooks(t *testing.T) {
 	testCfgGood := "./testdata/good-cfg.json"
 	testCfgBad := "./testdata/bad-cfg.json"
 	cases := []struct {
-		location    string
-		expectedLen int
-		expectedErr bool
+		location                    string
+		expectedLen                 int
+		expectedCreateRuntimeHook   int
+		expectedCreateContainerHook int
+		expectedStartContainerHook  int
+		expectedErr                 bool
 	}{
 		{
 			location:    testBundleNoExists,
@@ -122,9 +125,12 @@ func TestReadHooks(t *testing.T) {
 			expectedErr: true,
 		},
 		{
-			location:    testCfgGood,
-			expectedLen: 1,
-			expectedErr: false,
+			location:                    testCfgGood,
+			expectedLen:                 1,
+			expectedCreateRuntimeHook:   1,
+			expectedCreateContainerHook: 1,
+			expectedStartContainerHook:  1,
+			expectedErr:                 false,
 		},
 	}
 	for _, test := range cases {
@@ -149,10 +155,12 @@ func TestReadHooks(t *testing.T) {
 			!(spec != nil &&
 				spec.Hooks != nil &&
 				spec.Hooks.Prestart != nil &&
-				len(spec.Hooks.Prestart) == test.expectedLen) {
-
+				len(spec.Hooks.Prestart) == test.expectedLen &&
+				len(spec.Hooks.CreateRuntime) == test.expectedCreateRuntimeHook &&
+				len(spec.Hooks.CreateContainer) == test.expectedCreateContainerHook &&
+				len(spec.Hooks.StartContainer) == test.expectedStartContainerHook) {
 			t.Errorf("Did not parse the expected prestart path length. Got %+v expected %d from file %s",
-				spec,
+				spec.Hooks,
 				test.expectedLen,
 				test.location)
 		}

--- a/testdata/good-cfg.json
+++ b/testdata/good-cfg.json
@@ -8,6 +8,21 @@
 				"two"
 				]
 			}
+		],
+        "createRuntime": [
+			{
+				"path": "/tmp/made-up/things/config"
+			}
+		],
+        "createContainer": [
+			{
+				"path": "/tmp/made-up/things/config"
+			}
+		],
+        "startContainer": [
+			{
+				"path": "/tmp/made-up/things/config"
+			}
 		]
 	},
   "extra": "something extra"


### PR DESCRIPTION
support 3 new hooks
- createRuntime
- createContainer
- startContainer
https://github.com/opencontainers/runtime-spec/blob/master/config.md#posix-platform-hooks

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
