### PR TITLE
Support the new hook types of newer oci spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+oci-add-hooks

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/awslabs/oci-add-hooks
 
+go 1.15
+
 require (
 	github.com/bitly/go-simplejson v0.5.0 // indirect
 	github.com/joeshaw/json-lossless v0.0.0-20181204200226-e0cd1ca6349b

--- a/hook.go
+++ b/hook.go
@@ -70,6 +70,7 @@ func (c *config) merge(in *config) {
 	c.Hooks.StartContainer = mergeHook(c.Hooks.StartContainer, in.Hooks.StartContainer)
 	c.Hooks.Poststart = mergeHook(c.Hooks.Poststart, in.Hooks.Poststart)
 	c.Hooks.Poststop = mergeHook(c.Hooks.Poststop, in.Hooks.Poststop)
+
 }
 
 func readHooks(path string) (*config, error) {


### PR DESCRIPTION
This adds support for the new hooks that deprecate prestart in newer versions of containerd:

* createContainer
* createRuntime
* startContainer

Note that you need to be on container runtime that supports
the OCI runtime spec >= v1.0.2 to manipulate these hooks,
so I didn't add it into the README, but at least this tool will understand them if present.

Relates to https://github.com/opencontainers/runtime-spec/pull/1008

cc @alban

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
