### PR TITLE
Add CODEOWNERS file to repository

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global (repository-wide) owners:
+*    @awslabs/aws-ecs @awslabs/runtime


### PR DESCRIPTION
*Issue #, if available:*
(N/A)

*Description of changes:*
This PR adds a `CODEOWNERS` file to the repository, which designates the @awslabs/aws-ecs and @awslabs/runtime teams as primary owners.  This is in response to a campaign to make AWS-owned open source repositories more secure.  For more details on code owners, see [About code owners](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) (GitHub documentation).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
